### PR TITLE
[Feature]  user logout #59

### DIFF
--- a/src/main/java/com/ColdPitch/domain/entity/User.java
+++ b/src/main/java/com/ColdPitch/domain/entity/User.java
@@ -25,7 +25,7 @@ public class User extends BaseEntity {
     @Column(nullable = false)
     private String nickname;
 
-    private boolean userSocial = false;// 확장성
+    private boolean userSocial;// 확장성
 
     @Column(nullable = false)
     private String password;

--- a/src/main/java/com/ColdPitch/domain/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/ColdPitch/domain/repository/RefreshTokenRepository.java
@@ -8,4 +8,5 @@ import java.util.Optional;
 
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
     Optional<RefreshToken> findByKey(String key);
+    void deleteByKey(String key);
 }

--- a/src/main/java/com/ColdPitch/domain/service/RefreshTokenService.java
+++ b/src/main/java/com/ColdPitch/domain/service/RefreshTokenService.java
@@ -1,0 +1,20 @@
+package com.ColdPitch.domain.service;
+
+import com.ColdPitch.domain.entity.dto.jwt.RefreshToken;
+import com.ColdPitch.domain.repository.RefreshTokenRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class RefreshTokenService {
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    public Optional<RefreshToken> findKey(String key) {
+        return refreshTokenRepository.findByKey(key);
+    }
+}

--- a/src/main/java/com/ColdPitch/domain/service/UserService.java
+++ b/src/main/java/com/ColdPitch/domain/service/UserService.java
@@ -91,4 +91,13 @@ public class UserService {
         return tokenDto;
     }
 
+
+    public User findUserByEmail(String email) {
+        return userRepository.findByEmail(email);
+    }
+
+    @Transactional
+    public void logout(User nowLogin) {
+        refreshTokenRepository.deleteByKey(nowLogin.getEmail());
+    }
 }

--- a/src/main/java/com/ColdPitch/jwt/SecurityUtil.java
+++ b/src/main/java/com/ColdPitch/jwt/SecurityUtil.java
@@ -1,31 +1,48 @@
 package com.ColdPitch.jwt;
 
 
+import com.ColdPitch.domain.entity.User;
+import com.ColdPitch.domain.service.UserService;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
 
 import java.util.Optional;
 
 @Slf4j
+@RequiredArgsConstructor
+@Component
 public class SecurityUtil {
+    private final UserService userService;
+    //현재 시큐리티 컨텍스에 있는 유저정보와 권한을 준다. (이메일 아이디를 준다)
 
-    //현재 시큐리티 컨텍스에 있는 유저정보와 권한을 준다.
-    public static Optional<String> getCurrentUserLoginId() {
+    public Optional<String> getCurrentUserEmail() {
         final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         if (authentication == null) {
             log.info("Secutiry context의 정보가 없음");
             return Optional.empty();
         }
 
-        String userLoginId = null;
+        String userEmail = null;
         if (authentication.getPrincipal() instanceof UserDetails) {
             UserDetails springSecurityUser = (UserDetails) authentication.getPrincipal();
-            userLoginId = springSecurityUser.getUsername();
+            userEmail = springSecurityUser.getUsername();
         } else if (authentication.getPrincipal() instanceof String) {
-            userLoginId = (String) authentication.getPrincipal();
+            userEmail = (String) authentication.getPrincipal();
         }
-        return Optional.ofNullable(userLoginId);
+        return Optional.ofNullable(userEmail);
+    }
+
+    public Optional<User> getCurrentUser() {
+        User userByEmail = null;
+        Optional<String> currentUserEmail = getCurrentUserEmail();
+        if (currentUserEmail.isPresent()) {
+            log.info("current USER EMAIL : {}",currentUserEmail.get());
+            userByEmail = userService.findUserByEmail(currentUserEmail.get());
+        }
+        return Optional.ofNullable(userByEmail);
     }
 }

--- a/src/test/java/com/ColdPitch/domain/service/UserServiceTest.java
+++ b/src/test/java/com/ColdPitch/domain/service/UserServiceTest.java
@@ -30,6 +30,8 @@ class UserServiceTest {
     PasswordEncoder passwordEncoder;
     @Autowired
     TokenProvider tokenProvider;
+    @Autowired
+    RefreshTokenService refreshTokenService;
 
     @Test
     @DisplayName("유저회원 회원가입을 확인한다. ")
@@ -77,6 +79,22 @@ class UserServiceTest {
             userService.login(loginDto);
         });
 
+    }
+
+    @Test
+    @DisplayName("유저 로그아웃을 확인한다.")
+    public void logoutTestsuite() {
+        //given
+        UserRequestDto userRequestDto = new UserRequestDto("nickname", "name", "password", "email@naver.com", "010-7558-2452", "USER");
+        User signup = userService.signup(userRequestDto);
+        LoginDto loginDto = new LoginDto("email@naver.com", "password");
+        TokenDto login = userService.login(loginDto);
+
+        //when
+        userService.logout(signup);
+
+        //then ( 생성된 토큰의 유효성을 확인한다. )
+        assertThat(refreshTokenService.findKey(signup.getEmail())).isEqualTo(java.util.Optional.empty());
     }
 
     private boolean checkPassword(String password, String exPassword) {


### PR DESCRIPTION
close : #59 

- 유저로그아웃 시에 리프레시 토큰 삭제
- 서비스 테스트 코드
- 컨트롤러 테스트 코드
- 유저테이블 필름 default 동작 하지 않음으로 제거
- SecurityUtil.java 를 컴포넌트로 수정하여 DI 가능하도록 하고 로그인한 유저를 바로 불러올수 있도록 메소드 추가 