### PR TITLE
[Feature] comment soft delete 구현 #11

### DIFF
--- a/src/main/java/com/ColdPitch/domain/apicontroller/CommentApiController.java
+++ b/src/main/java/com/ColdPitch/domain/apicontroller/CommentApiController.java
@@ -1,6 +1,5 @@
 package com.ColdPitch.domain.apicontroller;
 
-import com.ColdPitch.domain.entity.Comment;
 import com.ColdPitch.domain.entity.comment.CommentState;
 import com.ColdPitch.domain.entity.dto.comment.CommentRequestDto;
 import com.ColdPitch.domain.entity.dto.comment.CommentResponseDto;
@@ -8,12 +7,12 @@ import com.ColdPitch.domain.repository.CommentRepository;
 import com.ColdPitch.domain.service.CommentService;
 import io.swagger.v3.oas.annotations.Operation;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -22,14 +21,16 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
+@Transactional
 public class CommentApiController {
     private final CommentService commentService;
     private final CommentRepository commentRepository;
 
     @GetMapping("/comment")
+    @Transactional(readOnly = true)
     public ResponseEntity<List<CommentResponseDto>> getCommentList(Long id, String type) {
         if (id == null && type == null) {
-            return ResponseEntity.noContent().build();
+            return ResponseEntity.ok(commentService.findAll());
         }
 
         switch (type) {
@@ -40,6 +41,7 @@ public class CommentApiController {
                     return ResponseEntity.ok(commentRepository
                         .findAll()
                         .stream()
+                        .filter(comment -> !comment.getStatus().equals(CommentState.DELETED.toString()))
                         .map(CommentService::commentToResponseDto)
                         .collect(Collectors.toList())
                     );
@@ -54,7 +56,7 @@ public class CommentApiController {
                 break;
         }
 
-        return ResponseEntity.internalServerError().build();
+        return ResponseEntity.badRequest().build();
     }
 
     @PostMapping("/comment")
@@ -88,7 +90,7 @@ public class CommentApiController {
             return ResponseEntity.noContent().build();
         }
 
-        commentRepository.deleteById(commentId);
+        commentService.changeState(commentId, CommentState.DELETED);
 
         return ResponseEntity.ok().build();
     }
@@ -112,8 +114,8 @@ public class CommentApiController {
             CommentRequestDto requestDto = CommentRequestDto.builder()
                 .userId(i)
                 .text("dummy comment " + i)
-                .postId((long) ((1.0 - Math.random()) * Math.max(3, amount / 5)))
-                .pCommentId((long) ((1.0 - Math.random()) * Math.max(3, amount / 5)))
+                .postId((long) Math.max(1, (1.0 - Math.random()) * Math.max(3, amount / 5)))
+                .pCommentId((long) Math.max(1, (1.0 - Math.random()) * Math.max(3, amount / 5)))
                 .status(CommentState.CREATED.toString())
                 .build();
 

--- a/src/main/java/com/ColdPitch/domain/entity/Comment.java
+++ b/src/main/java/com/ColdPitch/domain/entity/Comment.java
@@ -42,6 +42,10 @@ public class Comment extends BaseEntity {
         this.pCommentId = pCommentId;
     }
 
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/src/main/java/com/ColdPitch/domain/repository/CommentRepositoryCustom.java
+++ b/src/main/java/com/ColdPitch/domain/repository/CommentRepositoryCustom.java
@@ -5,8 +5,17 @@ import java.util.List;
 
 public interface CommentRepositoryCustom {
     List<Comment> findAllByPostId(Long postId);
+    List<Comment> findAllByPostIdForAdmin(Long postId);
 
-    List<Comment> findAllByParentId(Long replyId);
+    List<Comment> findAllByParentId(Long pCommentId);
+    List<Comment> findAllByParentIdForAdmin(Long pCommentId);
 
     List<Comment> findAllByUserId(Long userId);
+    List<Comment> findAllByUserIdForAdmin(Long userId);
+
+    List<Comment> findAllForUser();
+
+    List<Comment> findAllForAdmin();
+
+    Comment findByIdForUser(Long id);
 }

--- a/src/main/java/com/ColdPitch/domain/repository/CommentRepositoryImpl.java
+++ b/src/main/java/com/ColdPitch/domain/repository/CommentRepositoryImpl.java
@@ -2,16 +2,37 @@ package com.ColdPitch.domain.repository;
 
 import com.ColdPitch.domain.entity.Comment;
 import com.ColdPitch.domain.entity.QComment;
+import com.ColdPitch.domain.entity.comment.CommentState;
+import com.ColdPitch.utils.SecurityUtil;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
+@Transactional
+@Slf4j
 public class CommentRepositoryImpl implements CommentRepositoryCustom {
+
     private final JPAQueryFactory queryFactory;
 
     @Override
+    @Transactional(readOnly = true)
     public List<Comment> findAllByPostId(Long postId) {
+        return queryFactory
+            .selectFrom(QComment.comment)
+            .where(QComment.comment.postId.eq(postId))
+            .where(QComment.comment.status.ne(CommentState.DELETED.toString()))
+            .fetch();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<Comment> findAllByPostIdForAdmin(Long postId) {
         return queryFactory
             .selectFrom(QComment.comment)
             .where(QComment.comment.postId.eq(postId))
@@ -19,18 +40,70 @@ public class CommentRepositoryImpl implements CommentRepositoryCustom {
     }
 
     @Override
-    public List<Comment> findAllByParentId(Long parentId) {
+    @Transactional(readOnly = true)
+    public List<Comment> findAllByParentId(Long pCommentId) {
         return queryFactory
             .selectFrom(QComment.comment)
-            .where(QComment.comment.pCommentId.eq(parentId))
+            .where(QComment.comment.pCommentId.eq(pCommentId))
+            .where(QComment.comment.status.ne(CommentState.DELETED.toString()))
             .fetch();
     }
 
     @Override
+    @Transactional(readOnly = true)
+    public List<Comment> findAllByParentIdForAdmin(Long pCommentId) {
+        return queryFactory
+            .selectFrom(QComment.comment)
+            .where(QComment.comment.pCommentId.eq(pCommentId))
+            .fetch();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
     public List<Comment> findAllByUserId(Long userId) {
         return queryFactory
             .selectFrom(QComment.comment)
             .where(QComment.comment.userId.eq(userId))
+            .where(QComment.comment.status.ne(CommentState.DELETED.toString()))
             .fetch();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<Comment> findAllByUserIdForAdmin(Long userId) {
+        return queryFactory
+            .selectFrom(QComment.comment)
+            .where(QComment.comment.userId.eq(userId))
+            .fetch();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<Comment> findAllForUser() {
+        return queryFactory
+            .selectFrom(QComment.comment)
+            .where(QComment.comment.status.ne(CommentState.DELETED.toString()))
+            .fetch();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<Comment> findAllForAdmin() {
+        return queryFactory
+            .selectFrom(QComment.comment)
+            .fetch();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Comment findByIdForUser(Long id) {
+        return queryFactory
+            .selectFrom(QComment.comment)
+            .where(QComment.comment.id.eq(id))
+            .where(QComment.comment.status.ne(CommentState.DELETED.toString()))
+            .fetch()
+            .stream()
+            .findAny()
+            .orElse(null);
     }
 }

--- a/src/main/java/com/ColdPitch/utils/SecurityUtil.java
+++ b/src/main/java/com/ColdPitch/utils/SecurityUtil.java
@@ -1,9 +1,11 @@
 package com.ColdPitch.utils;
 
 
+import java.util.Collection;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 
@@ -29,5 +31,47 @@ public class SecurityUtil {
             userEmail = (String) authentication.getPrincipal();
         }
         return Optional.ofNullable(userEmail);
+    }
+
+    /**
+     * 현재 SecurityContext에 있는 유저의 권한 컬렉션을 리턴
+     *
+     * @return
+     * UserDetails
+     * 유저의 권한 컬렉션을 리턴
+     */
+    public static Optional<Collection<? extends GrantedAuthority>> getCurrentUserAuthorities() {
+        final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null) {
+            log.info("Secutiry context의 정보가 없음");
+            return Optional.empty();
+        }
+
+        return Optional.of(authentication.getAuthorities());
+    }
+
+    /**
+     * 현재 주어진 role과 SecurityContext에 있는 유저를 비교하여 Boolean값 리턴
+     * @param role
+     * 유저의 역할
+     * @return
+     * 동일할 경우 true, 그외의 경우에는 false
+     */
+    public static boolean checkCurrentUserRole(String role) {
+        final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null) {
+            log.info("Secutiry context의 정보가 없음");
+            return false;
+        }
+
+        Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
+
+        for (GrantedAuthority authority : authorities) {
+            if (authority.getAuthority().equals(role)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }


### PR DESCRIPTION
refactor(comment): Comment 엔티티 status Setter 추가, CommentService와 CommentRepository에서 조회에서는 readOnly 조건 추가
feat(comment): Comment 조회시 유저 권한에 따라 삭제된 댓글은 조회되지 않도록 함
feat(comment): Admin용 조회 메소드 추가
feat(security): SecurityUtil에 SecurityContext의 현재 유저 권한을 리턴하는 메소드와 주어진 권한을 가지고 있는지 체크하는 메소드 추가