### PR TITLE
[Feature] user 탈퇴시 논리적 삭제기능으로 추가 #58

### DIFF
--- a/src/main/java/com/ColdPitch/domain/apicontroller/UserApiController.java
+++ b/src/main/java/com/ColdPitch/domain/apicontroller/UserApiController.java
@@ -43,6 +43,13 @@ public class UserApiController {
         return ResponseEntity.status(200).body(userService.updateProfile(authentication.getName(), userRequestDto));
     }
 
+    @DeleteMapping
+    @Operation(summary = "유저 탈퇴")
+    public ResponseEntity<Void> deleteUser(@ApiIgnore Authentication authentication) {
+        userService.deleteUser(authentication.getName());
+        return ResponseEntity.status(200).build();
+    }
+
     @GetMapping("/dummy")
     @Operation(summary = "USER 더미데이터 생성", description = "default USER, 원하는 경우 ADMIN 입력")
     public ResponseEntity<List<UserResponseDto>> makeDummyUser(@RequestParam(defaultValue = "USER", name = "userType(Default : USER)") String userType, @RequestParam(defaultValue = "5", name = "size(Default : 5)") int size) {
@@ -59,7 +66,7 @@ public class UserApiController {
     @Operation(summary = "USER 테스트 토큰 생성")
     public ResponseEntity<String> makeDummyUserToken() {
         UserRequestDto urd = new UserRequestDto("testNick", "testName", "testPass", "testEamil@naver.com", "010-1234-1234", "USER");
-        userService.deleteByEmail(urd.getEmail());
+        userService.deleteUser(urd.getEmail());
         userService.signup(urd);
         TokenDto login = userService.login(new LoginDto(urd.getEmail(), urd.getPassword()));
         return ResponseEntity.status(200).body("Bearer " + login.getAccessToken());
@@ -69,7 +76,7 @@ public class UserApiController {
     @Operation(summary = "ADMIN 테스트 토큰 생성")
     public ResponseEntity<String> makeDummyAdminToken() {
         UserRequestDto urd = new UserRequestDto("testANick", "testAName", "testAPass", "testAEamil@naver.com", "010-5678-5678", "ADMIN");
-        userService.deleteByEmail(urd.getEmail());
+        userService.deleteUser(urd.getEmail());
         userService.signup(urd);
         TokenDto login = userService.login(new LoginDto(urd.getEmail(), urd.getPassword()));
         return ResponseEntity.status(200).body("Bearer " + login.getAccessToken());

--- a/src/main/java/com/ColdPitch/domain/apicontroller/UserApiController.java
+++ b/src/main/java/com/ColdPitch/domain/apicontroller/UserApiController.java
@@ -4,6 +4,7 @@ import com.ColdPitch.domain.entity.dto.jwt.TokenDto;
 import com.ColdPitch.domain.entity.dto.user.LoginDto;
 import com.ColdPitch.domain.entity.dto.user.UserRequestDto;
 import com.ColdPitch.domain.entity.dto.user.UserResponseDto;
+import com.ColdPitch.domain.repository.UserRepository;
 import com.ColdPitch.domain.service.UserService;
 import com.ColdPitch.utils.RandomUtil;
 import io.swagger.v3.oas.annotations.Operation;
@@ -23,6 +24,7 @@ import java.util.List;
 @RequestMapping("/api/v1/user")
 public class UserApiController {
     private final UserService userService;
+    private final UserRepository userRepository; //더미네이터 생성으로 인해 잠시 추가 나중에 삭제할것임
 
     @GetMapping
     @Operation(summary = "유저 전체 조회 ( 이후에 ADMIN 권한으로 열기)")
@@ -66,7 +68,7 @@ public class UserApiController {
     @Operation(summary = "USER 테스트 토큰 생성")
     public ResponseEntity<String> makeDummyUserToken() {
         UserRequestDto urd = new UserRequestDto("testNick", "testName", "testPass", "testEamil@naver.com", "010-1234-1234", "USER");
-        userService.deleteUser(urd.getEmail());
+        userRepository.deleteByEmail(urd.getEmail());
         userService.signup(urd);
         TokenDto login = userService.login(new LoginDto(urd.getEmail(), urd.getPassword()));
         return ResponseEntity.status(200).body("Bearer " + login.getAccessToken());
@@ -76,7 +78,7 @@ public class UserApiController {
     @Operation(summary = "ADMIN 테스트 토큰 생성")
     public ResponseEntity<String> makeDummyAdminToken() {
         UserRequestDto urd = new UserRequestDto("testANick", "testAName", "testAPass", "testAEamil@naver.com", "010-5678-5678", "ADMIN");
-        userService.deleteUser(urd.getEmail());
+        userRepository.deleteByEmail(urd.getEmail());
         userService.signup(urd);
         TokenDto login = userService.login(new LoginDto(urd.getEmail(), urd.getPassword()));
         return ResponseEntity.status(200).body("Bearer " + login.getAccessToken());

--- a/src/main/java/com/ColdPitch/domain/apicontroller/UserAuthApiController.java
+++ b/src/main/java/com/ColdPitch/domain/apicontroller/UserAuthApiController.java
@@ -47,8 +47,9 @@ public class UserAuthApiController {
 
     @PostMapping("/logout")
     @Operation(summary = "로그아웃", description = "리프레시 토큰 삭제")
-    public void logout(@ApiIgnore Authentication authentication) {
+    public ResponseEntity<Void> logout(@ApiIgnore Authentication authentication) {
         userService.logout(authentication.getName());
+        return ResponseEntity.status(200).build();
     }
 
     @PostMapping("/reissue")

--- a/src/main/java/com/ColdPitch/domain/entity/User.java
+++ b/src/main/java/com/ColdPitch/domain/entity/User.java
@@ -7,6 +7,8 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 import javax.persistence.*;
 
@@ -14,6 +16,8 @@ import javax.persistence.*;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SuperBuilder(toBuilder = true)
+@SQLDelete(sql = "UPDATE user SET cur_state = 'DELETED' WHERE user_id = ?")
+@Where(clause = "cur_state != 'DELETED'")
 public class User extends BaseEntity {
     @Id //userId
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -23,7 +27,7 @@ public class User extends BaseEntity {
     @Column(nullable = false)
     private String name;
 
-    @Column(nullable = false, unique = true)
+    @Column(nullable = false)
     private String nickname;
 
     private boolean userSocial;// 확장성
@@ -31,7 +35,7 @@ public class User extends BaseEntity {
     @Column(nullable = false)
     private String password;
 
-    @Column(nullable = false,unique = true)
+    @Column(nullable = false)
     private String email;
 
     @Column(nullable = false)

--- a/src/main/java/com/ColdPitch/domain/repository/UserRepository.java
+++ b/src/main/java/com/ColdPitch/domain/repository/UserRepository.java
@@ -2,8 +2,11 @@ package com.ColdPitch.domain.repository;
 
 import com.ColdPitch.domain.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -15,4 +18,10 @@ public interface UserRepository extends JpaRepository<User, Long>, UserRepositor
     Optional<User> findByNickname(String nickname);
 
     void deleteByEmail(String email);
+
+    @Query(value = "SELECT * FROM user", nativeQuery = true)
+    Optional<List<User>> findAllUserIncludeDeletedUser(); //삭제된 유저까지 전부 조회
+
+    @Query(value = "SELECT * FROM user WHERE email = :email", nativeQuery = true)
+    Optional<List<User>> findUserByEmailIncludeDeletedUser(@Param("email") String email); //삭제된 유저 포함해서 email중에 조회
 }

--- a/src/main/java/com/ColdPitch/domain/service/UserService.java
+++ b/src/main/java/com/ColdPitch/domain/service/UserService.java
@@ -127,7 +127,8 @@ public class UserService {
     }
 
     @Transactional
-    public void deleteByEmail(String email) {
+    public void deleteUser(String email) {
+        logout(email); //리프레시 토큰을 삭제한다.
         userRepository.deleteByEmail(email);
     }
 }

--- a/src/main/java/com/ColdPitch/domain/service/UserService.java
+++ b/src/main/java/com/ColdPitch/domain/service/UserService.java
@@ -128,6 +128,11 @@ public class UserService {
 
     @Transactional
     public void deleteUser(String email) {
+        //TODO 수정시에 validation 확인 ( 로그인한 사람이 본인이 맞는지 확인 )
+        List<User> users = userRepository.findUserByEmailIncludeDeletedUser(email).orElseThrow();
+        if (!users.isEmpty() && users.get(0).getCurState()==CurState.DELETED) {
+            throw new RequestRejectedException("이미 탈퇴한 회원입니다.");
+        }
         logout(email); //리프레시 토큰을 삭제한다.
         userRepository.deleteByEmail(email);
     }

--- a/src/test/java/com/ColdPitch/domain/apicontroller/UserControllerTest.java
+++ b/src/test/java/com/ColdPitch/domain/apicontroller/UserControllerTest.java
@@ -1,0 +1,75 @@
+package com.ColdPitch.domain.apicontroller;
+
+import com.ColdPitch.domain.entity.User;
+import com.ColdPitch.domain.entity.dto.jwt.TokenDto;
+import com.ColdPitch.domain.entity.dto.user.LoginDto;
+import com.ColdPitch.domain.entity.dto.user.UserRequestDto;
+import com.ColdPitch.domain.repository.UserRepository;
+import com.ColdPitch.domain.service.RefreshTokenService;
+import com.ColdPitch.domain.service.UserService;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+@Slf4j
+class UserControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private UserService userService;
+    @Autowired
+    private RefreshTokenService refreshTokenService;
+
+    private User user1, admin1;
+    private TokenDto userToken1, adminToken1;
+
+    @Test
+    @DisplayName("유저 탈퇴 확인")
+    public void loginFailTest() throws Exception {
+        //given
+        //before each 유저 설정
+
+        //when 회원가입 되지 않은 유저 로그인시에
+        mockMvc.perform(delete("/api/v1/user")
+                        .header("Authorization", "Bearer " + userToken1.getAccessToken())
+                        .contentType(MediaType.APPLICATION_JSON_VALUE))
+                .andExpect(status().isOk())
+                .andDo(print());
+
+        //then
+        assertThat(userRepository.findByEmail(user1.getEmail())).isEmpty(); //user1이 조회되지 않는다.
+    }
+
+
+    @BeforeEach
+    public void initUser() {
+        userService.signup(new UserRequestDto("nickname", "name", "password", "email@naver.com", "010-7558-2452", "USER"));
+        userService.signup(new UserRequestDto("Anickname", "Aname", "Apassword", "Aemail@naver.com", "010-7558-2444", "ADMIN"));
+
+        user1 = userRepository.findByNickname("nickname").orElseThrow();
+        admin1 = userRepository.findByNickname("Anickname").orElseThrow();
+
+        userToken1 = userService.login(new LoginDto("email@naver.com", "password"));
+        adminToken1 = userService.login(new LoginDto("Aemail@naver.com", "Apassword"));
+    }
+
+
+}


### PR DESCRIPTION
close #58 

- 기본적으로 jpa 조회시에는 select 문에서 자동으로 delete상태가 아닌경우의 멤버만 조회한다.
- 삭제시에는 유저의 상태를 Delete로 변경한다 + refresh token 삭제(logout method)
- 만약 삭제된 유저도 함께 조회하고 싶다면 jpql native query 사용하면 된다. 
- 테스트 코드 추가