### PR TITLE
[Feature] user tag table 생성 #117

### DIFF
--- a/src/main/java/com/ColdPitch/domain/apicontroller/TagApiController.java
+++ b/src/main/java/com/ColdPitch/domain/apicontroller/TagApiController.java
@@ -1,12 +1,15 @@
 package com.ColdPitch.domain.apicontroller;
 
 import com.ColdPitch.domain.entity.Tag;
+import com.ColdPitch.domain.entity.dto.tag.TagRequestDto;
+import com.ColdPitch.domain.entity.dto.usertag.TagResponseDto;
 import com.ColdPitch.domain.service.TagService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/api/v1/tags")
@@ -20,14 +23,12 @@ public class TagApiController {
     }
 
     @GetMapping
-    public ResponseEntity<List<Tag>> getAllTags() {
-        List<Tag> tags = tagService.getAllTags();
-        return ResponseEntity.ok(tags);
+    public ResponseEntity<List<TagResponseDto>> getAllTags() {
+        return ResponseEntity.ok(tagService.getAllTags().stream().map(TagResponseDto::of).collect(Collectors.toList()));
     }
 
     @PostMapping
-    public ResponseEntity<Tag> createTag(@RequestBody Tag tag) {
-        Tag createdTag = tagService.createTag(tag);
-        return ResponseEntity.ok(createdTag);
+    public ResponseEntity<TagResponseDto> createTag(TagRequestDto tagRequestDto) {
+        return ResponseEntity.ok(TagResponseDto.of(tagService.createTag(tagRequestDto)));
     }
 }

--- a/src/main/java/com/ColdPitch/domain/apicontroller/UserTagController.java
+++ b/src/main/java/com/ColdPitch/domain/apicontroller/UserTagController.java
@@ -1,0 +1,34 @@
+package com.ColdPitch.domain.apicontroller;
+
+import com.ColdPitch.domain.entity.dto.usertag.UserTagRequestDto;
+import com.ColdPitch.domain.entity.dto.usertag.TagResponseDto;
+import com.ColdPitch.domain.service.UserService;
+import com.ColdPitch.domain.service.UserTagService;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+@RequestMapping("/api/v1/usertag")
+public class UserTagController {
+    private final UserService userService;
+    private final UserTagService userTagService;
+
+    @PostMapping
+    @Operation(summary = "유저 - 테그 등록, 유저 테그 정보를 ENUM으로 받아온다. 로그인 되어있다는 가정")
+    public ResponseEntity<List<TagResponseDto>> saveUserTag(@RequestBody UserTagRequestDto userTagRequestDto) {
+        return ResponseEntity.status(200).body(userTagService.setTag(userTagRequestDto,userService.getMemberWithAuthorities().orElseThrow(IllegalAccessError::new)));
+    }
+
+    @GetMapping
+    @Operation(summary = "자신의 유저 테그 조회 ")
+    public ResponseEntity<List<TagResponseDto>> findMyPost() {
+        return ResponseEntity.status(200).body(userTagService.findMyTag(userService.getMemberWithAuthorities().orElseThrow(IllegalAccessError::new)));
+    }
+}

--- a/src/main/java/com/ColdPitch/domain/entity/Tag.java
+++ b/src/main/java/com/ColdPitch/domain/entity/Tag.java
@@ -4,6 +4,7 @@ import lombok.*;
 import lombok.experimental.SuperBuilder;
 
 import javax.persistence.*;
+import java.util.List;
 
 @Entity
 @Getter
@@ -21,6 +22,9 @@ public class Tag extends BaseEntity {
 
     @Column(nullable = false)
     private String description;
+
+    @OneToMany(mappedBy = "tag", fetch = FetchType.LAZY,cascade = CascadeType.ALL)
+    private List<UserTag> userTags;
 
     @Override
     public String toString() {

--- a/src/main/java/com/ColdPitch/domain/entity/Tag.java
+++ b/src/main/java/com/ColdPitch/domain/entity/Tag.java
@@ -2,6 +2,7 @@ package com.ColdPitch.domain.entity;
 
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import net.minidev.json.annotate.JsonIgnore;
 
 import javax.persistence.*;
 import java.util.List;
@@ -23,6 +24,7 @@ public class Tag extends BaseEntity {
     @Column(nullable = false)
     private String description;
 
+    @JsonIgnore
     @OneToMany(mappedBy = "tag", fetch = FetchType.LAZY,cascade = CascadeType.ALL)
     private List<UserTag> userTags;
 

--- a/src/main/java/com/ColdPitch/domain/entity/User.java
+++ b/src/main/java/com/ColdPitch/domain/entity/User.java
@@ -7,6 +7,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import net.minidev.json.annotate.JsonIgnore;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
 
@@ -46,8 +47,6 @@ public class User extends BaseEntity {
     @OneToOne(fetch = FetchType.LAZY)
     private CompanyRegistration companyRegistration;
 
-    @OneToMany(fetch = FetchType.LAZY, mappedBy = "user",cascade = CascadeType.ALL)
-    private List<UserTag> userTags;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
@@ -57,6 +56,11 @@ public class User extends BaseEntity {
     @Column(nullable = false)
     private CurState curState;
 
+    @JsonIgnore
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "user", cascade = CascadeType.ALL)
+    private List<UserTag> userTags;
+
+    @JsonIgnore
     @OneToMany(mappedBy = "user")//외래키를 가진쪽 연관관계의 주인
     private List<Post> posts = new ArrayList<>();
 

--- a/src/main/java/com/ColdPitch/domain/entity/User.java
+++ b/src/main/java/com/ColdPitch/domain/entity/User.java
@@ -46,6 +46,9 @@ public class User extends BaseEntity {
     @OneToOne(fetch = FetchType.LAZY)
     private CompanyRegistration companyRegistration;
 
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "user",cascade = CascadeType.ALL)
+    private List<UserTag> userTags;
+
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private UserType userType;

--- a/src/main/java/com/ColdPitch/domain/entity/UserTag.java
+++ b/src/main/java/com/ColdPitch/domain/entity/UserTag.java
@@ -18,11 +18,9 @@ public class UserTag extends BaseEntity {
     private Long id;
 
     @ManyToOne(fetch = LAZY)
-    @JoinColumn(name = "user_id")
     private User user;
 
     @ManyToOne(fetch = LAZY)
-    @JoinColumn(name = "tag_id")
     private Tag tag;
 
 

--- a/src/main/java/com/ColdPitch/domain/entity/UserTag.java
+++ b/src/main/java/com/ColdPitch/domain/entity/UserTag.java
@@ -1,0 +1,53 @@
+package com.ColdPitch.domain.entity;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+import static javax.persistence.FetchType.LAZY;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserTag extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @JoinColumn(name = "user_tag_id")
+    private Long id;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "tag_id")
+    private Tag tag;
+
+
+    //연관관계 편의 메소드
+    public void setUser(User user) {
+        this.user = user;
+        if (!user.getUserTags().contains(this)) {
+            user.getUserTags().add(this);
+        }
+    }
+
+    public void setTag(Tag tag) {
+        this.tag = tag;
+        if (!tag.getUserTags().contains(this)) {
+            tag.getUserTags().add(this);
+        }
+    }
+
+    public UserTag(User user, Tag tag) {
+        setUser(user);
+        setTag(tag);
+    }
+
+    public void delete() {
+        this.user.getUserTags().remove(this);
+        this.tag.getUserTags().remove(this);
+    }
+}

--- a/src/main/java/com/ColdPitch/domain/entity/dto/tag/TagRequestDto.java
+++ b/src/main/java/com/ColdPitch/domain/entity/dto/tag/TagRequestDto.java
@@ -1,0 +1,13 @@
+package com.ColdPitch.domain.entity.dto.tag;
+
+import lombok.*;
+
+@Getter
+@Setter
+@ToString
+@AllArgsConstructor
+@NoArgsConstructor
+public class TagRequestDto {
+    String tagName;
+    String description;
+}

--- a/src/main/java/com/ColdPitch/domain/entity/dto/usertag/TagResponseDto.java
+++ b/src/main/java/com/ColdPitch/domain/entity/dto/usertag/TagResponseDto.java
@@ -1,0 +1,23 @@
+package com.ColdPitch.domain.entity.dto.usertag;
+
+import com.ColdPitch.domain.entity.Tag;
+import com.ColdPitch.domain.entity.UserTag;
+import lombok.*;
+
+@Getter
+@Setter
+@ToString
+@AllArgsConstructor
+@NoArgsConstructor
+public class TagResponseDto {
+    String name;
+    String description;
+
+    public static TagResponseDto of(Tag tag) {
+        return new TagResponseDto(tag.getTagName(), tag.getDescription());
+    }
+
+    public static TagResponseDto of(UserTag userTag) {
+        return new TagResponseDto(userTag.getTag().getTagName(), userTag.getTag().getDescription());
+    }
+}

--- a/src/main/java/com/ColdPitch/domain/entity/dto/usertag/UserTagRequestDto.java
+++ b/src/main/java/com/ColdPitch/domain/entity/dto/usertag/UserTagRequestDto.java
@@ -1,0 +1,14 @@
+package com.ColdPitch.domain.entity.dto.usertag;
+
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Setter
+@ToString
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserTagRequestDto {
+    List<String> userTag;
+}

--- a/src/main/java/com/ColdPitch/domain/repository/TagRepository.java
+++ b/src/main/java/com/ColdPitch/domain/repository/TagRepository.java
@@ -4,6 +4,9 @@ import com.ColdPitch.domain.entity.Tag;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface TagRepository extends JpaRepository<Tag,Long> {
+    Optional<Tag> findByTagName(String tagName);
 }

--- a/src/main/java/com/ColdPitch/domain/repository/UserTagRepository.java
+++ b/src/main/java/com/ColdPitch/domain/repository/UserTagRepository.java
@@ -1,0 +1,7 @@
+package com.ColdPitch.domain.repository;
+
+import com.ColdPitch.domain.entity.UserTag;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserTagRepository extends JpaRepository<UserTag, Long> {
+}

--- a/src/main/java/com/ColdPitch/domain/service/TagService.java
+++ b/src/main/java/com/ColdPitch/domain/service/TagService.java
@@ -6,6 +6,7 @@ import com.ColdPitch.domain.repository.TagRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -23,7 +24,11 @@ public class TagService {
     }
 
     public Tag createTag(TagRequestDto tagRequestDto) {
-        return tagRepository.save(Tag.builder().tagName(tagRequestDto.getTagName()).description(tagRequestDto.getDescription()).build());
+        return tagRepository.save(Tag.builder()
+                .tagName(tagRequestDto.getTagName())
+                .description(tagRequestDto.getDescription())
+                .userTags(new ArrayList<>())
+                .build());
     }
 
     public Tag findTagByTagNameOrThrowException(String name) {

--- a/src/main/java/com/ColdPitch/domain/service/TagService.java
+++ b/src/main/java/com/ColdPitch/domain/service/TagService.java
@@ -1,11 +1,13 @@
 package com.ColdPitch.domain.service;
 
 import com.ColdPitch.domain.entity.Tag;
+import com.ColdPitch.domain.entity.dto.tag.TagRequestDto;
 import com.ColdPitch.domain.repository.TagRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 public class TagService {
@@ -20,8 +22,16 @@ public class TagService {
         return tagRepository.findAll();
     }
 
-    public Tag createTag(Tag tag) {
-        return tagRepository.save(tag);
+    public Tag createTag(TagRequestDto tagRequestDto) {
+        return tagRepository.save(Tag.builder().tagName(tagRequestDto.getTagName()).description(tagRequestDto.getDescription()).build());
+    }
+
+    public Tag findTagByTagNameOrThrowException(String name) {
+        return tagRepository.findByTagName(name).orElseThrow(IllegalAccessError::new);
+    }
+
+    public Optional<Tag> findTagByTagName(String name) {
+        return tagRepository.findByTagName(name);
     }
 
 }

--- a/src/main/java/com/ColdPitch/domain/service/UserService.java
+++ b/src/main/java/com/ColdPitch/domain/service/UserService.java
@@ -163,6 +163,9 @@ public class UserService {
                 .phoneNumber(userRequestDto.getPhoneNumber())
                 .userType(UserType.of(userRequestDto.getUserType()))
                 .curState(CurState.LIVE)
+                .posts(new ArrayList<>())
+                .userTags(new ArrayList<>())
+                .companyRegistration(null)
                 .nickname(userRequestDto.getNickname()).build();
     }
 
@@ -177,17 +180,17 @@ public class UserService {
 
         List<Post> posts = new ArrayList<>();
 
-        for(Like like : likes) {
+        for (Like like : likes) {
             posts.add(postRepository.findById(like.getPostId())
                     .orElseThrow(() -> new IllegalArgumentException("Invalid postId: " + like.getPostId())));
         }
 
-        for(Dislike dislike : dislikes) {
+        for (Dislike dislike : dislikes) {
             posts.add(postRepository.findById(dislike.getPostId())
                     .orElseThrow(() -> new IllegalArgumentException("Invalid postId: " + dislike.getPostId())));
         }
 
-        for(CommentResponseDto comment : comments) {
+        for (CommentResponseDto comment : comments) {
             posts.add(postRepository.findById(comment.getPostId())
                     .orElseThrow(() -> new IllegalArgumentException("Invalid postId: " + comment.getPostId())));
         }
@@ -201,7 +204,7 @@ public class UserService {
 
         return postResponses;
     }
-  
+
     public List<PostResponseDto> findMyWritePost(String email) {
         User user = userRepository.findOneWithAuthoritiesByEmail(email).orElseThrow();
         return user.getPosts().stream().map(o -> PostResponseDto.of(o, null)).collect(Collectors.toList());

--- a/src/main/java/com/ColdPitch/domain/service/UserService.java
+++ b/src/main/java/com/ColdPitch/domain/service/UserService.java
@@ -14,6 +14,7 @@ import com.ColdPitch.domain.entity.user.CurState;
 import com.ColdPitch.domain.entity.user.UserType;
 import com.ColdPitch.domain.repository.*;
 import com.ColdPitch.jwt.TokenProvider;
+import com.ColdPitch.utils.SecurityUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -110,6 +111,11 @@ public class UserService {
 
     public User findUserByEmail(String email) {
         return userRepository.findByEmail(email).orElseThrow();
+    }
+
+    //현재 시큐리티 컨텍스에 있는 유저정보와 권환 정보를 준다
+    public Optional<User> getMemberWithAuthorities() {
+        return SecurityUtil.getCurrentUserEmail().flatMap(userRepository::findOneWithAuthoritiesByEmail);
     }
 
     @Transactional

--- a/src/main/java/com/ColdPitch/domain/service/UserTagService.java
+++ b/src/main/java/com/ColdPitch/domain/service/UserTagService.java
@@ -1,0 +1,48 @@
+package com.ColdPitch.domain.service;
+
+import com.ColdPitch.domain.entity.Tag;
+import com.ColdPitch.domain.entity.User;
+import com.ColdPitch.domain.entity.UserTag;
+import com.ColdPitch.domain.entity.dto.usertag.TagResponseDto;
+import com.ColdPitch.domain.entity.dto.usertag.UserTagRequestDto;
+import com.ColdPitch.domain.repository.UserTagRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class UserTagService {
+    private final UserTagRepository userTagRepository;
+    private final TagService tagService;
+
+    @Transactional
+    public List<TagResponseDto> setTag(UserTagRequestDto userTagRequestDto, User user) {
+        initUserTag(user); //TODO 해당 부분은 추후에 리팩토링 (수정 하는 경우 같은 메서드를 사용할 것 인지)
+        List<TagResponseDto> userTagResponse = new ArrayList<>();
+        for (String nowTag : userTagRequestDto.getUserTag()) {
+            Tag tag = tagService.findTagByTagNameOrThrowException(nowTag);
+            userTagResponse.add(TagResponseDto.of(userTagRepository.save(new UserTag(user, tag))));
+        }
+
+        //유저에게 테그 달기
+        return userTagResponse;
+    }
+
+    private static void initUserTag(User user) {
+        for (UserTag userTag : user.getUserTags()) {
+            userTag.delete();
+        }
+    }
+
+    public List<TagResponseDto> findMyTag(User user) {
+        return user.getUserTags().stream().map(TagResponseDto::of).collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/ColdPitch/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/ColdPitch/exception/handler/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import com.google.gson.JsonObject;
 import java.util.NoSuchElementException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
@@ -30,6 +31,14 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         return ResponseEntity.status(204).body(body);
     }
 
+    @ExceptionHandler(AuthenticationException.class)
+    protected ResponseEntity<?> handlerLogin(NoSuchElementException e) {
+        JsonObject jsonObject = new JsonObject();
+        jsonObject.addProperty("message", e.getMessage());
+        String body = new Gson().toJson(jsonObject);
+
+        return ResponseEntity.status(400).body(body);
+    }
 
     @ExceptionHandler(Exception.class)
     protected ResponseEntity<?> handlerException(Exception e) {

--- a/src/test/java/com/ColdPitch/domain/apicontroller/UserTagControllerTest.java
+++ b/src/test/java/com/ColdPitch/domain/apicontroller/UserTagControllerTest.java
@@ -1,0 +1,118 @@
+package com.ColdPitch.domain.apicontroller;
+
+import com.ColdPitch.domain.entity.Tag;
+import com.ColdPitch.domain.entity.User;
+import com.ColdPitch.domain.entity.UserTag;
+import com.ColdPitch.domain.entity.dto.jwt.TokenDto;
+import com.ColdPitch.domain.entity.dto.tag.TagRequestDto;
+import com.ColdPitch.domain.entity.dto.user.LoginDto;
+import com.ColdPitch.domain.entity.dto.user.UserRequestDto;
+import com.ColdPitch.domain.entity.dto.usertag.UserTagRequestDto;
+import com.ColdPitch.domain.repository.UserRepository;
+import com.ColdPitch.domain.repository.UserTagRepository;
+import com.ColdPitch.domain.service.TagService;
+import com.ColdPitch.domain.service.UserService;
+import com.ColdPitch.domain.service.UserTagService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+@Slf4j
+class UserTagControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private UserService userService;
+    @Autowired
+    private TagService tagService;
+    @Autowired
+    private UserTagRepository userTagRepository;
+    @Autowired
+    private UserTagService userTagService;
+
+    private User user;
+    private TokenDto login;
+    private Tag tag1, tag2, tag3;
+
+    @Test
+    @DisplayName("유저 테그입력 테스트")
+    public void setTagTest() throws Exception {
+        //given
+        Assertions.assertThat(userService.findUserByEmail(user.getEmail()).getNickname()).isEqualTo(user.getNickname());
+        ObjectMapper objectMapper = new ObjectMapper();
+        UserTagRequestDto userTagRequestDto = new UserTagRequestDto(List.of("tag1", "tag2"));
+        String requestBody = objectMapper.writeValueAsString(userTagRequestDto);
+
+        //when 회원가입 되지 않은 유저 로그인시에
+        mockMvc.perform(post("/api/v1/usertag")
+                        .contentType(MediaType.APPLICATION_JSON_VALUE)
+                        .content(requestBody)
+                        .header("Authorization", "Bearer " + login.getAccessToken()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].name").value("tag1"))
+                .andExpect(jsonPath("$[1].name").value("tag2"))
+                .andDo(print());
+
+        //then
+        List<UserTag> allUserTags = userTagRepository.findAll();
+        assertThat(allUserTags.size()).isEqualTo(2);
+        assertThat(allUserTags.get(0).getTag()).isEqualTo(tag1);
+        assertThat(allUserTags.get(0).getUser()).isEqualTo(user);
+        assertThat(allUserTags.get(1).getTag()).isEqualTo(tag2);
+        assertThat(allUserTags.get(1).getUser()).isEqualTo(user);
+    }
+
+    @Test
+    @DisplayName("유저 테그조회 테스트")
+    public void findTagTest() throws Exception {
+        //given
+        userTagService.setTag(new UserTagRequestDto(List.of("tag1", "tag2", "tag3")), user);
+
+        //when 회원가입 되지 않은 유저 로그인시에
+        mockMvc.perform(get("/api/v1/usertag")
+                        .contentType(MediaType.APPLICATION_JSON_VALUE)
+                        .header("Authorization", "Bearer " + login.getAccessToken()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].name").value("tag1"))
+                .andExpect(jsonPath("$[0].description").value("tag1"))
+                .andExpect(jsonPath("$[1].name").value("tag2"))
+                .andExpect(jsonPath("$[1].description").value("tag2"))
+                .andExpect(jsonPath("$[2].name").value("tag3"))
+                .andExpect(jsonPath("$[2].description").value("tag3"))
+                .andExpect(jsonPath("$[3]").doesNotExist())
+                .andDo(print());
+    }
+
+    @BeforeEach
+    public void initUser() {
+        userService.signUpUser(new UserRequestDto("nickname", "name", "password", "email@naver.com", "010-7558-2452", "USER"));
+        user = userRepository.findByNickname("nickname").orElseThrow();
+        login = userService.login(new LoginDto("email@naver.com", "password"));
+        tag1 = tagService.createTag(new TagRequestDto("tag1", "tag1"));
+        tag2 = tagService.createTag(new TagRequestDto("tag2", "tag2"));
+        tag3 = tagService.createTag(new TagRequestDto("tag3", "tag3"));
+    }
+}

--- a/src/test/java/com/ColdPitch/domain/service/UserServiceTest.java
+++ b/src/test/java/com/ColdPitch/domain/service/UserServiceTest.java
@@ -30,15 +30,15 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class UserServiceTest {
 
     @Autowired
-    UserService userService;
+    private UserService userService;
     @Autowired
-    UserRepository userRepository;
+    private UserRepository userRepository;
     @Autowired
-    PasswordEncoder passwordEncoder;
+    private PasswordEncoder passwordEncoder;
     @Autowired
-    TokenProvider tokenProvider;
+    private TokenProvider tokenProvider;
     @Autowired
-    RefreshTokenService refreshTokenService;
+    private RefreshTokenService refreshTokenService;
     private UserRequestDto userRequestDto;
 
     @BeforeEach

--- a/src/test/java/com/ColdPitch/domain/service/UserTagServiceTest.java
+++ b/src/test/java/com/ColdPitch/domain/service/UserTagServiceTest.java
@@ -1,0 +1,65 @@
+package com.ColdPitch.domain.service;
+
+import com.ColdPitch.domain.entity.Tag;
+import com.ColdPitch.domain.entity.User;
+import com.ColdPitch.domain.entity.UserTag;
+import com.ColdPitch.domain.entity.dto.tag.TagRequestDto;
+import com.ColdPitch.domain.entity.dto.user.UserRequestDto;
+import com.ColdPitch.domain.entity.dto.usertag.UserTagRequestDto;
+import com.ColdPitch.domain.repository.UserTagRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+@Slf4j
+class UserTagServiceTest {
+
+    @Autowired
+    private UserService userService;
+    @Autowired
+    private TagService tagService;
+    @Autowired
+    private UserTagService userTagService;
+    @Autowired
+    private UserTagRepository userTagRepository;
+
+    private User user;
+    private Tag tag1, tag2;
+
+    @Test
+    @DisplayName("유저회원 테그 입력 기능 확인")
+    public void addUserTag() {
+        //given
+
+        // when
+        userTagService.setTag(new UserTagRequestDto(List.of("tag1", "tag2")), user);
+
+        //then
+        List<UserTag> allUserTags = userTagRepository.findAll();
+        assertThat(allUserTags.size()).isEqualTo(2);
+        assertThat(allUserTags.get(0).getTag()).isEqualTo(tag1);
+        assertThat(allUserTags.get(0).getUser()).isEqualTo(user);
+        assertThat(allUserTags.get(1).getTag()).isEqualTo(tag2);
+        assertThat(allUserTags.get(1).getUser()).isEqualTo(user);
+    }
+
+    @BeforeEach
+    private void initUser() {
+        UserRequestDto userRequestDto = new UserRequestDto("nickname", "name", "password", "email@naver.com", "010-7558-2452", "USER");
+        userService.signUpUser(userRequestDto);
+        user = userService.findUserByEmail(userRequestDto.getEmail());
+        tag1 = tagService.createTag(new TagRequestDto("tag1", "tag1"));
+        tag2 = tagService.createTag(new TagRequestDto("tag2", "tag2"));
+    }
+
+}


### PR DESCRIPTION
close #117 
close  #120 

- 태그 생성 DTO 분리
- 유저 태그 테이블 생성
- 유저 자신의 태그 조회기능 생성
- 테스트 코드 ( 서비스로직, 컨트롤러 로직 일부 작성, 에러 상황은 테스트 안함)
- 로그인의 경우 Authentication 에러 발생해서 익셉션 핸들러 수정
- 접근제어자 일부 수정