### PR TITLE
[Feature] #149 유저 댓글 긍부정 평가 API 호출 로직 작성

### DIFF
--- a/src/main/java/com/ColdPitch/config/okHttp/ApiConfig.java
+++ b/src/main/java/com/ColdPitch/config/okHttp/ApiConfig.java
@@ -19,5 +19,7 @@ import org.springframework.stereotype.Component;
 @ToString
 @Component
 public class ApiConfig {
-    private String serviceKey;
+    private String companyServiceKey;
+    private String sentimentKeyId;
+    private String sentimentKey;
 }

--- a/src/main/java/com/ColdPitch/domain/entity/dto/sentiment/SentimentRequestDto.java
+++ b/src/main/java/com/ColdPitch/domain/entity/dto/sentiment/SentimentRequestDto.java
@@ -1,0 +1,8 @@
+package com.ColdPitch.domain.entity.dto.sentiment;
+
+import lombok.Data;
+
+@Data
+public class SentimentRequestDto {
+    private String text;
+}

--- a/src/main/java/com/ColdPitch/domain/entity/dto/sentiment/SentimentResponseDto.java
+++ b/src/main/java/com/ColdPitch/domain/entity/dto/sentiment/SentimentResponseDto.java
@@ -1,0 +1,25 @@
+package com.ColdPitch.domain.entity.dto.sentiment;
+
+import lombok.Data;
+
+@Data
+public class SentimentResponseDto {
+    private Document document;
+
+    @Data
+    public static class Document {
+        private Sentiment sentiment;
+        private Confidence confidence;
+
+        @Data
+        public static class Sentiment {
+            private String label;   // 감정: negative, positive
+        }
+
+        @Data
+        public static class Confidence {
+            private double negative;
+            private double positive;
+        }
+    }
+}

--- a/src/main/java/com/ColdPitch/domain/service/CompanyRegistrationValidator.java
+++ b/src/main/java/com/ColdPitch/domain/service/CompanyRegistrationValidator.java
@@ -38,7 +38,7 @@ public class CompanyRegistrationValidator {
         Request request = new Request.Builder()
                 .header("Access-Control-Request-Method", "POST")
                 .header("Origin", ServerUtil.getCurrentBaseUrl())
-                .url(API_URL + apiConfig.getServiceKey())
+                .url(API_URL + apiConfig.getCompanyServiceKey())
                 .post(body)
                 .build();
 

--- a/src/main/java/com/ColdPitch/domain/service/SentimentApiClient.java
+++ b/src/main/java/com/ColdPitch/domain/service/SentimentApiClient.java
@@ -1,0 +1,47 @@
+package com.ColdPitch.domain.service;
+
+import com.ColdPitch.config.okHttp.ApiConfig;
+import com.ColdPitch.domain.entity.dto.sentiment.SentimentRequestDto;
+import com.ColdPitch.domain.entity.dto.sentiment.SentimentResponseDto;
+import com.ColdPitch.exception.CustomException;
+import com.ColdPitch.exception.handler.ErrorCode;
+import com.google.gson.Gson;
+import lombok.RequiredArgsConstructor;
+import okhttp3.*;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+
+@Service
+@RequiredArgsConstructor
+public class SentimentApiClient {
+    private final String API_URL = "https://naveropenapi.apigw.ntruss.com/sentiment-analysis/v1/analyze";
+    private final ApiConfig apiConfig;
+    private final OkHttpClient client;
+    private final Gson gson;
+
+    public SentimentResponseDto callSentimentApi(SentimentRequestDto requestDto) {
+        MediaType mediaType = MediaType.parse("application/json; charset=utf-8");
+        String json = gson.toJson(requestDto);
+
+        RequestBody body = RequestBody.create(mediaType, json);
+        Request request = new Request.Builder()
+                .header("X-NCP-APIGW-API-KEY-ID", apiConfig.getSentimentKeyId())
+                .header("X-NCP-APIGW-API-KEY", apiConfig.getSentimentKey())
+                .header("Content-Type", "application/json")
+                .url(API_URL)
+                .post(body)
+                .build();
+
+        try (Response response = client.newCall(request).execute()) {
+            if (!response.isSuccessful()) {
+                throw new CustomException(ErrorCode.SENTIMENT_EXTERNAL_API_ERROR);
+            }
+
+            String responseBody = response.body().string();
+            return gson.fromJson(responseBody, SentimentResponseDto.class);
+        } catch (IOException e) {
+            throw new CustomException(ErrorCode.SENTIMENT_EXTERNAL_API_ERROR);
+        }
+    }
+}

--- a/src/main/java/com/ColdPitch/domain/service/SentimentService.java
+++ b/src/main/java/com/ColdPitch/domain/service/SentimentService.java
@@ -1,0 +1,33 @@
+package com.ColdPitch.domain.service;
+
+import com.ColdPitch.domain.entity.Comment;
+import com.ColdPitch.domain.entity.dto.sentiment.SentimentRequestDto;
+import com.ColdPitch.domain.entity.dto.sentiment.SentimentResponseDto;
+import com.ColdPitch.domain.repository.CommentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class SentimentService {
+
+    private final CommentRepository commentRepository;
+    private final SentimentApiClient sentimentAnalysisApiClient;
+
+    public SentimentResponseDto analyzeSentiment(Long postId) {
+        List<Comment> comments = commentRepository.findAllByPostId(postId);
+
+        // 여러 댓글을 하나의 문자열로 병합
+        String commentsText = comments.stream()
+                .map(Comment::getText)
+                .collect(Collectors.joining(" "));
+
+        SentimentRequestDto requestDto = new SentimentRequestDto();
+        requestDto.setText(commentsText);
+        return sentimentAnalysisApiClient.callSentimentApi(requestDto);
+    }
+}
+

--- a/src/main/java/com/ColdPitch/exception/handler/ErrorCode.java
+++ b/src/main/java/com/ColdPitch/exception/handler/ErrorCode.java
@@ -60,7 +60,10 @@ public enum ErrorCode {
     // CompanyRegistration
     COMPANY_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않는 기업입니다."),
     COMPANY_EXTERNAL_API_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "외부 요청 API에서 에러가 발생하였습니다."),
-    COMPANY_BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다.");
+    COMPANY_BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+
+    // Sentiment
+    SENTIMENT_EXTERNAL_API_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "외부 요청 API에서 에러가 발생하였습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/test/java/com/ColdPitch/domain/service/SentimentServiceTest.java
+++ b/src/test/java/com/ColdPitch/domain/service/SentimentServiceTest.java
@@ -1,0 +1,65 @@
+package com.ColdPitch.domain.service;
+
+import com.ColdPitch.domain.entity.Comment;
+import com.ColdPitch.domain.entity.Post;
+import com.ColdPitch.domain.entity.dto.sentiment.SentimentResponseDto;
+import com.ColdPitch.domain.entity.dto.sentiment.SentimentResponseDto.Document;
+import com.ColdPitch.domain.repository.CommentRepository;
+import com.ColdPitch.domain.repository.PostRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class SentimentServiceTest {
+
+    @InjectMocks
+    private SentimentService sentimentAnalysisService;
+
+    @Mock
+    private PostRepository postRepository;
+
+    @Mock
+    private CommentRepository commentRepository;
+
+    @Mock
+    private SentimentApiClient sentimentApiClient;
+
+    @Test
+    public void testAnalyzePostSentiment() {
+        // Given
+        Long postId = 1L;
+        Post post = Post.builder().id(postId).build();
+        Comment comment1 = Comment.builder().text("싸늘하다. 가슴에 비수가 날아와 꽂힌다.").build();
+        Comment comment2 = Comment.builder().text("하지만 걱정하지 마라. 손은 눈보다 빠르니까.").build();
+
+        when(postRepository.findById(postId)).thenReturn(Optional.of(post));
+        when(commentRepository.findAllByPostId(postId)).thenReturn(Arrays.asList(comment1, comment2));
+
+        SentimentResponseDto responseDto = new SentimentResponseDto();
+        Document document = new Document();
+        Document.Sentiment sentiment = new Document.Sentiment();
+        sentiment.setLabel("positive");
+        document.setSentiment(sentiment);
+        responseDto.setDocument(document);
+
+        when(sentimentApiClient.callSentimentApi(any())).thenReturn(responseDto);
+
+
+        // When
+        sentimentAnalysisService.analyzeSentiment(postId);
+
+        // Then
+        verify(postRepository, times(1)).findById(postId);
+        verify(commentRepository, times(1)).findAllByPostId(postId);
+        verify(sentimentApiClient, times(1)).callSentimentApi(any());
+    }
+}


### PR DESCRIPTION
close #149 

긍부정 분석 Api
- NAVER CLOUD PLATFORM의 AI NAVER API의 CLOVA Sentiment API 사용
  (https://api.ncloud-docs.com/docs/ai-naver-clovasentiment-api)
- postId로 조회한 게시글의 댓글들을 하나의 문자열로 병합한 후, 한 번에 외부 api로 보내서 전체적인 감정을 분석한 결과를 반환
- request : String (postId를 파라미터로 주면, 해당 게시글의 댓글을 하나의 String 형식으로 합친 후 요청)
- response : String (negative/positive), double(negative/positive percent)

Api Service Key 네이밍 변경
- 사업자 등록번호 검증 : serviceKey -> companyServiceKey
- 감정 분석 : sentimentServiceKey, sentimentServiceKeyId